### PR TITLE
Fix type compatibility for Symfony 7

### DIFF
--- a/Console/Command/GeolocateIP.php
+++ b/Console/Command/GeolocateIP.php
@@ -50,7 +50,7 @@ class GeolocateIP extends Command
      * @return int|null
      * @throws Exception
      */
-    protected function execute(InputInterface $input, OutputInterface $output): ?int
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (empty($input->getOption('ip'))) {
             throw new Exception('IP address is required.');

--- a/Console/Command/GeolocateIP.php
+++ b/Console/Command/GeolocateIP.php
@@ -47,7 +47,7 @@ class GeolocateIP extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int|null
+     * @return int
      * @throws Exception
      */
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
This will be necessary for Magento 2.4.9 / Mage-OS 3.0 to avoid a fatal error due to type conflict with the upstream method